### PR TITLE
Publish dotty/state for HA handshake

### DIFF
--- a/main.py
+++ b/main.py
@@ -90,6 +90,16 @@ def _mqtt_on_message(client, userdata, msg):
 def _mqtt_on_disconnect(client, userdata, rc):
     log.warning("MQTT disconnected rc=%s", rc)
 
+def publish_state(state: str):
+    """Publish dotty/state retained so HA can wait_for_trigger on display state."""
+    if mqtt_client is None:
+        return
+    try:
+        mqtt_client.publish("dotty/state", state, qos=1, retain=True)
+        log.info("Published dotty/state=%s", state)
+    except Exception:
+        log.exception("publish_state(%s) failed", state)
+
 # ---------------------------
 # MQTT client management (single instance)
 # ---------------------------
@@ -439,6 +449,7 @@ def main():
 
     # Initial draw (Instant)
     draw_hours_and_bottom(h, m, DISPLAY_INVERTED)
+    publish_state("time")
 
     log.info("Entering main loop")
     while True:
@@ -463,9 +474,11 @@ def main():
                 log.info("Processing command from queue: %s", cmd_norm)
                 if cmd_norm == "blank":
                     clear_display(panels, inverted=DISPLAY_INVERTED, refresh_fn=refresh)
+                    publish_state("blank")
                 elif cmd_norm == "refresh":
                     hh, mm, ss = get_time()
                     draw_hours_and_bottom(hh, mm, DISPLAY_INVERTED)
+                    publish_state("time")
                 else:
                     log.info("Unknown command: %s", cmd)
 


### PR DESCRIPTION
## Summary

Adds a retained MQTT state topic so Home Assistant can `wait_for_trigger` on dotty's actual display state instead of using fixed delays for the goodnight/morning routines.

- New `publish_state(state)` helper publishes to `dotty/state` retained, qos=1.
- After processing the `blank` command → `publish_state("blank")`.
- After processing the `refresh` command → `publish_state("time")`.
- After the initial `draw_hours_and_bottom` on boot → `publish_state("time")` so HA knows dotty is up and rendering.

Internal state changes (minute transitions, hour transitions) don't republish — those are still "time", so retained value stays correct.

## Test plan

- [ ] After deploy, `mosquitto_sub -t 'dotty/state' -v` should immediately show the retained value (whatever the current display is).
- [ ] `mosquitto_pub -t dotty/command -m blank` → state topic flips to `blank`.
- [ ] `mosquitto_pub -t dotty/command -m refresh` → state topic flips to `time`.
- [ ] Restart `dotty.service` → after boot draw, retained `dotty/state` is `time`.

## HA companion change

Paired with a homeassistant PR that swaps the fixed delays in Goodnight / Morning / early_bed_time for `wait_for_trigger` on this topic.

https://claude.ai/code/session_01UvLweTQ4Mjv5245E6WHxDD

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvLweTQ4Mjv5245E6WHxDD)_