### PR TITLE
Add MQTT Last Will so dotty/status flips to offline on disconnect

### DIFF
--- a/main.py
+++ b/main.py
@@ -115,6 +115,8 @@ def build_mqtt_client():
     client = mqtt.Client(client_id=client_id, protocol=mqtt.MQTTv311)
     if MQTT_USER:
         client.username_pw_set(MQTT_USER, MQTT_PASS)
+    # LWT: broker publishes offline if dotty drops the connection ungracefully
+    client.will_set("dotty/status", "offline", qos=1, retain=True)
     client.on_connect = _mqtt_on_connect
     client.on_message = _mqtt_on_message
     client.on_disconnect = _mqtt_on_disconnect


### PR DESCRIPTION
## Summary

One-line addition to the MQTT client: register a Last Will so the broker auto-publishes `dotty/status: offline` (retained) if dotty drops the connection without sending a clean DISCONNECT.

```python
client.will_set("dotty/status", "offline", qos=1, retain=True)
```

This complements the existing `dotty/status: online` published in `_mqtt_on_connect`. After a power-cut, crash, or network drop, the broker fires the LWT once the keepalive timeout expires (~90s with the current `keepalive=60`).

## Why

The retained `dotty/status: online` from a previous session sticks around forever without LWT, so HA can't tell if dotty's actually up. With LWT, HA's binary_sensor will reliably reflect connection state.

## Pairs with

homeassistant PR — adds `binary_sensor.dotty_connection` reading this topic, plus dashboard cards.

## Test plan

- [ ] Deploy on the Pi (`updateDotty.sh`), restart `dotty.service`.
- [ ] `mosquitto_sub -t 'dotty/status' -v` shows `online` after dotty connects.
- [ ] Yank network on the Pi (or `sudo systemctl stop dotty.service` and pull mosquitto's keepalive timeout) → after ~90s `dotty/status` flips to `offline`.
- [ ] Restart dotty → flips back to `online`.

https://claude.ai/code/session_01UvLweTQ4Mjv5245E6WHxDD

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvLweTQ4Mjv5245E6WHxDD)_