### PR TITLE
updateDotty.sh: preserve local *.env across git reset --hard

### DIFF
--- a/updateDotty.sh
+++ b/updateDotty.sh
@@ -54,6 +54,17 @@ if [ -d "$REPO_DIR/.git" ]; then
     echo "[*] repo exists at $REPO_DIR — updating"
     cd "$REPO_DIR" || { echo "[ERR] cd $REPO_DIR failed"; exit 1; }
 
+    # Back up local-only *.env files before fetch+reset, in case any of them
+    # were tracked-then-deleted upstream (git reset --hard would otherwise
+    # remove them from the working tree).
+    ENV_BACKUP_DIR=$(mktemp -d -t dotty-env-XXXXXX)
+    echo "[*] backing up local *.env files to $ENV_BACKUP_DIR"
+    for envfile in "$REPO_DIR"/*.env; do
+        if [ -e "$envfile" ]; then
+            cp -p "$envfile" "$ENV_BACKUP_DIR/" && echo "    backed up $(basename "$envfile")"
+        fi
+    done
+
     # ensure remote exists
     if ! git remote get-url origin >/dev/null 2>&1; then
         echo "[*] adding origin $REPO_URL"
@@ -78,6 +89,18 @@ if [ -d "$REPO_DIR/.git" ]; then
     if ! git reset --hard "origin/$DEFAULT_BRANCH"; then
         echo "[WARN] git reset --hard origin/$DEFAULT_BRANCH failed"
     fi
+
+    # Restore any *.env files that the reset removed.
+    echo "[*] restoring local *.env files if missing"
+    for backup in "$ENV_BACKUP_DIR"/*.env; do
+        if [ -e "$backup" ]; then
+            name=$(basename "$backup")
+            if [ ! -f "$REPO_DIR/$name" ]; then
+                cp -p "$backup" "$REPO_DIR/$name" && echo "    restored $name"
+            fi
+        fi
+    done
+    rm -rf "$ENV_BACKUP_DIR"
 
     echo "[*] repo recent commits:"
     git --no-pager log -n 5 --pretty=format:'  %h %ad %s <%an>' --date=short || true


### PR DESCRIPTION
## Summary

Backs up local `*.env` files before `git reset --hard origin/master` and restores any that the reset removes. Prevents the dotty crash that happened today when PR #10's deletion of `mqtt.env` got pulled and wiped the local `mqtt.env`, which the systemd unit's `EnvironmentFile=` requires.

## Diff in plain English

Inside the "repo exists, update" branch:

```bash
# NEW: before fetch+reset
ENV_BACKUP_DIR=$(mktemp -d -t dotty-env-XXXXXX)
for envfile in "$REPO_DIR"/*.env; do
    [ -e "$envfile" ] && cp -p "$envfile" "$ENV_BACKUP_DIR/"
done

# (existing fetch + reset --hard)

# NEW: after reset, restore anything the reset removed
for backup in "$ENV_BACKUP_DIR"/*.env; do
    [ -e "$backup" ] || continue
    name=$(basename "$backup")
    [ ! -f "$REPO_DIR/$name" ] && cp -p "$backup" "$REPO_DIR/$name"
done
rm -rf "$ENV_BACKUP_DIR"
```

The "fresh clone" branch is unchanged — no env files to preserve on first install.

## Test plan

- [ ] Deploy + run `updateDotty.sh` once: log shows `backed up mqtt.env` then `restored mqtt.env if missing` (no actual restore needed since the file is in the working tree this time around).
- [ ] As a destructive test: `git rm mqtt.env && git commit -m "test"` on a throwaway branch, push, then pull — confirm the local `mqtt.env` is restored after `updateDotty.sh` runs and the service starts cleanly.

## Notes

- Backup goes to `mktemp -d` so each run is isolated, no stale files.
- Restore only happens if the file is **missing** post-reset — never overwrites a fresh upstream copy.
- Glob `*.env` is broad on purpose: any future env file (e.g. `serial.env`) would be protected the same way.

https://claude.ai/code/session_01UvLweTQ4Mjv5245E6WHxDD

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvLweTQ4Mjv5245E6WHxDD)_