### PR TITLE
Netflix splash: play baked green-screen video clip (with drawn fallback)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 .env
 *.env
 
+# Baked playback clips are generated locally by tools/make_netflix_clip.py
+assets/*.npz
+
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 

--- a/main.py
+++ b/main.py
@@ -492,6 +492,47 @@ def display_netflix_logo(pan, refresh_fn=refresh, step_delay: float = 0.03):
     for y in range(bottom, top - 1, -1):
         light_row(y, rx)
 
+# Baked clip produced by tools/make_netflix_clip.py (white-on-black 1-bit frames).
+NETFLIX_CLIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets", "netflix.npz")
+
+def load_clip(path):
+    """Load a baked 1-bit clip. Returns (frames(n,H,W) uint8, fps) or None."""
+    if not os.path.exists(path):
+        return None
+    try:
+        data = np.load(path)
+        shape = tuple(int(v) for v in data["shape"])
+        n = int(np.prod(shape))
+        frames = np.unpackbits(data["frames"])[:n].reshape(shape).astype(np.uint8)
+        fps = float(data["fps"]) if "fps" in data.files else 12.0
+        return frames, fps
+    except Exception:
+        log.exception("Failed to load clip %s", path)
+        return None
+
+def play_clip(pan, frames, fps, refresh_fn=refresh):
+    """Play baked frames, pushing only changed pixels so the slow flip-dot bus
+    redraws just the panels that actually changed between frames."""
+    if pan is None or len(frames) == 0:
+        return
+    delay = 1.0 / fps if fps > 0 else 0.08
+    prev = None
+    for fr in frames:
+        fh, fw = fr.shape
+        if prev is None:
+            for y in range(min(fh, HEIGHT)):
+                for x in range(min(fw, WIDTH)):
+                    pan.draw(x, y, int(fr[y, x]))
+        else:
+            ys, xs = np.where(fr != prev)
+            for y, x in zip(ys, xs):
+                if 0 <= x < WIDTH and 0 <= y < HEIGHT:
+                    pan.draw(int(x), int(y), int(fr[y, x]))
+        if refresh_fn:
+            refresh_fn()
+        prev = fr
+        time.sleep(delay)
+
 # ---------------------------
 # Main loop
 # ---------------------------
@@ -540,7 +581,13 @@ def main():
                     draw_hours_and_bottom(hh, mm, DISPLAY_INVERTED)
                     publish_state("time")
                 elif cmd_norm == "netflix":
-                    display_netflix_logo(panels, refresh_fn=refresh)
+                    clip = load_clip(NETFLIX_CLIP_PATH)
+                    if clip is not None:
+                        frames, fps = clip
+                        play_clip(panels, frames, fps, refresh_fn=refresh)
+                    else:
+                        log.info("No baked clip at %s; using drawn animation", NETFLIX_CLIP_PATH)
+                        display_netflix_logo(panels, refresh_fn=refresh)
                     publish_state("netflix")
                 else:
                     log.info("Unknown command: %s", cmd)

--- a/tools/make_netflix_clip.py
+++ b/tools/make_netflix_clip.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Download a green-screen video and bake it into a 28x28 1-bit clip Dotty can play.
+
+This is one-time preprocessing. Run it on a machine with internet access and
+ffmpeg installed (the Pi is fine):
+
+    pip install -r tools/requirements.txt
+    python3 tools/make_netflix_clip.py                 # uses the default URL
+    python3 tools/make_netflix_clip.py <URL> -o assets/netflix.npz
+
+It chroma-keys the green background out (subject = anything not green), scales
+to 28x28, and writes a compressed .npz of packed 1-bit frames (white logo on a
+black field). main.py plays that file back with numpy only -- no OpenCV needed
+at runtime.
+"""
+import argparse
+import os
+import sys
+import tempfile
+
+import numpy as np
+
+DEFAULT_URL = "https://youtu.be/tH5z8x_diW8"
+SIZE = 28
+
+
+def download(url, dst_dir):
+    import yt_dlp
+    out = os.path.join(dst_dir, "src.%(ext)s")
+    opts = {
+        "format": "bestvideo[ext=mp4]/best[ext=mp4]/best",
+        "outtmpl": out,
+        "quiet": True,
+        "noplaylist": True,
+    }
+    with yt_dlp.YoutubeDL(opts) as ydl:
+        info = ydl.extract_info(url, download=True)
+        return ydl.prepare_filename(info)
+
+
+def center_square(frame):
+    h, w = frame.shape[:2]
+    s = min(h, w)
+    y0 = (h - s) // 2
+    x0 = (w - s) // 2
+    return frame[y0:y0 + s, x0:x0 + s]
+
+
+def frame_to_bits(frame, h_lo, h_hi, s_min, v_min, lum_min):
+    """Square-crop, drop the green background, downscale, return a 28x28 0/1 array."""
+    import cv2
+    sq = center_square(frame)
+    hsv = cv2.cvtColor(sq, cv2.COLOR_BGR2HSV)
+    green = cv2.inRange(hsv, (h_lo, s_min, v_min), (h_hi, 255, 255))
+    fg = cv2.bitwise_not(green)                 # subject = anything not green
+    gray = cv2.cvtColor(sq, cv2.COLOR_BGR2GRAY)
+    fg[gray < lum_min] = 0                       # drop dark fringes / shadows
+    small = cv2.resize(fg, (SIZE, SIZE), interpolation=cv2.INTER_AREA)
+    return (small >= 128).astype(np.uint8)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("url", nargs="?", default=DEFAULT_URL)
+    ap.add_argument("-o", "--out", default="assets/netflix.npz")
+    ap.add_argument("--fps", type=float, default=12.0, help="playback frames per second")
+    ap.add_argument("--max-frames", type=int, default=300)
+    ap.add_argument("--green", default="35,85",
+                    help="green hue range lo,hi (OpenCV scale 0-179)")
+    ap.add_argument("--s-min", type=int, default=70, help="min saturation counted as green")
+    ap.add_argument("--v-min", type=int, default=40, help="min value counted as green")
+    ap.add_argument("--lum-min", type=int, default=60,
+                    help="subject pixels darker than this are dropped")
+    args = ap.parse_args()
+
+    try:
+        import cv2  # noqa: F401
+    except ImportError:
+        sys.exit("OpenCV missing. Run: pip install -r tools/requirements.txt")
+
+    h_lo, h_hi = (int(x) for x in args.green.split(","))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        print(f"Downloading {args.url} ...")
+        try:
+            path = download(args.url, tmp)
+        except Exception as e:
+            sys.exit(f"Download failed: {e}\n(Is yt-dlp installed and ffmpeg on PATH?)")
+
+        import cv2
+        cap = cv2.VideoCapture(path)
+        src_fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+        step = max(1, int(round(src_fps / args.fps)))
+        print(f"Source ~{src_fps:.1f} fps; sampling every {step} frame(s).")
+
+        frames = []
+        idx = 0
+        while len(frames) < args.max_frames:
+            ret, frame = cap.read()
+            if not ret:
+                break
+            if idx % step == 0:
+                frames.append(frame_to_bits(frame, h_lo, h_hi,
+                                            args.s_min, args.v_min, args.lum_min))
+            idx += 1
+        cap.release()
+
+    if not frames:
+        sys.exit("No frames decoded -- check the URL and that ffmpeg is installed.")
+
+    arr = np.array(frames, dtype=np.uint8)        # (n, 28, 28) of 0/1
+    os.makedirs(os.path.dirname(args.out) or ".", exist_ok=True)
+    np.savez_compressed(args.out,
+                        frames=np.packbits(arr),
+                        shape=np.array(arr.shape, dtype=np.int64),
+                        fps=np.float32(args.fps))
+    lit = arr.mean() * 100
+    print(f"Wrote {args.out}: {arr.shape[0]} frames @ {args.fps} fps, {lit:.1f}% lit avg")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,6 @@
+# Deps for the one-time clip baker (tools/make_netflix_clip.py).
+# Not needed at runtime -- main.py plays baked clips with numpy only.
+# Also requires ffmpeg installed on the system (apt install ffmpeg).
+yt-dlp>=2024.1.0
+opencv-python-headless>=4.5
+numpy>=1.21


### PR DESCRIPTION
## Summary
Adds a `netflix` MQTT command that shows a Netflix splash on the 28×28 flip-dot display, plus a pipeline to bake a real green-screen video clip into a playable file.

- **`tools/make_netflix_clip.py`** — one-time preprocessor: downloads a green-screen video (yt-dlp), chroma-keys the green background out (subject = anything not green), center-crops + scales to 28×28, thresholds to 1-bit, and saves compressed frames to `assets/netflix.npz`. White (lit) logo on a black field.
- **`main.py`** — `load_clip()` / `play_clip()` play the baked clip using **numpy only** (no OpenCV at runtime), pushing just the changed pixels each frame so the slow mechanical bus only redraws panels that actually change.
- The `netflix` command **plays the baked clip when present**, and **falls back to a hand-drawn "N" sweep animation** when `assets/netflix.npz` doesn't exist yet.
- Publishes `dotty/state=netflix` (retained) so Home Assistant can react/confirm.

## One-time setup (run on the Pi or any box with internet + ffmpeg)
```bash
sudo apt install ffmpeg
pip install -r tools/requirements.txt
python3 tools/make_netflix_clip.py            # uses the linked video by default
# or: python3 tools/make_netflix_clip.py <URL> -o assets/netflix.npz
```
Tunables: `--fps`, `--max-frames`, `--green lo,hi`, `--s-min`, `--v-min`, `--lum-min` for dialing in the chroma key. The `.npz` is git-ignored (generated per-device).

## Trigger
```
mosquitto_pub -t dotty/command -m netflix      # play splash
mosquitto_pub -t dotty/command -m refresh       # back to clock
```

### Home Assistant button
```yaml
mqtt:
  button:
    - name: "Dotty Netflix Splash"
      unique_id: dotty_netflix_splash
      command_topic: "dotty/command"
      payload_press: "netflix"
      icon: "mdi:netflix"
    - name: "Dotty Reset"
      unique_id: dotty_reset
      command_topic: "dotty/command"
      payload_press: "refresh"
      icon: "mdi:clock-outline"
```

## Notes / what I couldn't verify here
- This sandbox has no internet/ffmpeg/OpenCV, so the actual clip was not downloaded or baked — the tool is written and byte-compiles, but **run it once on the device** to generate `assets/netflix.npz`.
- Until that file exists, the command still works via the drawn-animation fallback.
- Playback fps and chroma-key thresholds want a check on real hardware.

## Test plan
- [x] `python3 -m py_compile main.py tools/make_netflix_clip.py` passes.
- [ ] Run `make_netflix_clip.py` on a networked machine; confirm `assets/netflix.npz` is produced.
- [ ] On hardware: publish `netflix`, confirm clip playback (or fallback animation if no clip), then `refresh` restores the clock.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JnhN2YV9QcxUJP5WuwUgya)_