### PR TITLE
Netflix clip: revert kill-switch + AV1 baker fix

### DIFF
--- a/main.py
+++ b/main.py
@@ -494,6 +494,9 @@ def display_netflix_logo(pan, refresh_fn=refresh, step_delay: float = 0.03):
 
 # Baked clip produced by tools/make_netflix_clip.py (white-on-black 1-bit frames).
 NETFLIX_CLIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets", "netflix.npz")
+# Kill switch: `touch` this file to skip the baked clip and fall back to the drawn
+# animation -- instant revert if the clip misbehaves on the display, no restart needed.
+NETFLIX_CLIP_DISABLE_FILE = "/tmp/dotty_disable_netflix_clip"
 
 def load_clip(path):
     """Load a baked 1-bit clip. Returns (frames(n,H,W) uint8, fps) or None."""
@@ -581,12 +584,17 @@ def main():
                     draw_hours_and_bottom(hh, mm, DISPLAY_INVERTED)
                     publish_state("time")
                 elif cmd_norm == "netflix":
-                    clip = load_clip(NETFLIX_CLIP_PATH)
+                    if os.path.exists(NETFLIX_CLIP_DISABLE_FILE):
+                        log.info("Baked clip disabled via %s; using drawn animation", NETFLIX_CLIP_DISABLE_FILE)
+                        clip = None
+                    else:
+                        clip = load_clip(NETFLIX_CLIP_PATH)
+                        if clip is None:
+                            log.info("No baked clip at %s; using drawn animation", NETFLIX_CLIP_PATH)
                     if clip is not None:
                         frames, fps = clip
                         play_clip(panels, frames, fps, refresh_fn=refresh)
                     else:
-                        log.info("No baked clip at %s; using drawn animation", NETFLIX_CLIP_PATH)
                         display_netflix_logo(panels, refresh_fn=refresh)
                     publish_state("netflix")
                 else:

--- a/tools/make_netflix_clip.py
+++ b/tools/make_netflix_clip.py
@@ -28,7 +28,10 @@ def download(url, dst_dir):
     import yt_dlp
     out = os.path.join(dst_dir, "src.%(ext)s")
     opts = {
-        "format": "bestvideo[ext=mp4]/best[ext=mp4]/best",
+        # Prefer H.264 (avc1); never AV1 -- OpenCV/ffmpeg often can't decode av01
+        # (fails with "No frames decoded"), and AV1 software decode is painful on a Pi.
+        "format": ("bestvideo[vcodec^=avc1]/best[vcodec^=avc1]/"
+                   "bestvideo[ext=mp4][vcodec!*=av01]/best[ext=mp4][vcodec!*=av01]/best"),
         "outtmpl": out,
         "quiet": True,
         "noplaylist": True,


### PR DESCRIPTION
## Summary
- Add a `/tmp/dotty_disable_netflix_clip` kill switch so the `netflix` command falls back to the drawn 'N' animation instantly if the baked clip misbehaves on the display — no file deletion or service restart needed (same `/tmp` flag-file idiom as `dotty_show_seconds`).
- Fix the clip baker (`tools/make_netflix_clip.py`): the default yt-dlp format selector pulled an **AV1** stream that OpenCV/ffmpeg can't decode (`"No frames decoded"`). Now prefers H.264 and never AV1 (also relevant on the Pi, where AV1 software decode is painful).

## Deploy notes
- `assets/netflix.npz` is gitignored, so it does **not** ship via this PR. Copy it to the Pi's `/home/chase/Dotty/assets/` (`scp`) or bake it on the Pi with the fixed tool.
- After merge, run `updateDotty.sh` on the Pi (it resets to the default branch) and `sudo systemctl restart dotty.service`.

## Revert
- `touch /tmp/dotty_disable_netflix_clip` → next `netflix` command uses the safe drawn animation.
- `rm /tmp/dotty_disable_netflix_clip` → re-enables the baked clip.

## Test plan
- [x] `python3 -m py_compile main.py tools/make_netflix_clip.py`
- [x] Baker produces a valid 239-frame clip that loads via `main.py`'s `load_clip`
- [ ] Confirm playback + revert flag on the physical flip-dot display

🤖 Generated with [Claude Code](https://claude.com/claude-code)