### PR TITLE
Netflix: resolve shimmer clip into crisp drawn N (follow-up to #16)

### DIFF
--- a/main.py
+++ b/main.py
@@ -492,6 +492,19 @@ def display_netflix_logo(pan, refresh_fn=refresh, step_delay: float = 0.03):
     for y in range(bottom, top - 1, -1):
         light_row(y, rx)
 
+def show_netflix_logo_still(pan, refresh_fn=refresh, hold: float = 1.0):
+    """Snap to the crisp geometric 'N' and hold, resolving the baked shimmer
+    clip into a clean logo (the 1-bit footage keys the logo too raggedly)."""
+    if pan is None:
+        return
+    buf = netflix_logo_buffer()
+    for y in range(HEIGHT):
+        for x in range(WIDTH):
+            pan.draw(x, y, int(buf[y, x]))
+    if refresh_fn:
+        refresh_fn()
+    time.sleep(hold)
+
 # Baked clip produced by tools/make_netflix_clip.py (white-on-black 1-bit frames).
 NETFLIX_CLIP_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "assets", "netflix.npz")
 # Kill switch: `touch` this file to skip the baked clip and fall back to the drawn
@@ -594,6 +607,7 @@ def main():
                     if clip is not None:
                         frames, fps = clip
                         play_clip(panels, frames, fps, refresh_fn=refresh)
+                        show_netflix_logo_still(panels, refresh_fn=refresh)
                     else:
                         display_netflix_logo(panels, refresh_fn=refresh)
                     publish_state("netflix")


### PR DESCRIPTION
## Why
PR #16 was merged while GitHub's PR view still showed only its first commit, so the merge captured the kill-switch + AV1 fix (`ac14740`) but **left behind the logo-cleanup commit** (`5b31d79`). This PR ships that missing change.

## Summary
- After the baked shimmer clip plays, snap to the geometric `netflix_logo_buffer()` 'N' and hold ~1s (`show_netflix_logo_still`). The 1-bit footage keys the logo too raggedly at 28px; this guarantees a crisp final logo while keeping the shimmer.

## Deploy
- Code-only; the baked `assets/netflix.npz` is unchanged (no asset copy needed).
- After merge: `sudo systemctl restart dotty.service` on the Pi, then `mosquitto_pub -t dotty/command -m netflix`.

## Test plan
- [x] `python3 -m py_compile main.py`
- [ ] Confirm shimmer → crisp N → hold on the physical display

🤖 Generated with [Claude Code](https://claude.com/claude-code)